### PR TITLE
fix container killing

### DIFF
--- a/adds/start.sh
+++ b/adds/start.sh
@@ -27,7 +27,7 @@ if [ -f ${CONFFILENAME} ]; then
 
 	cd /riot-web/webapp
 	echo "-=> riot.im options: http-server ${options}"
-	http-server ${options}
+	exec http-server ${options}
 else
 	echo "You need a conffile /data/riot.im.conf in you conf folder"
 	exit 1


### PR DESCRIPTION
sh does not redirect the SIGTERM, so the container times out and receives a SIGKILL (see https://www.ctl.io/developers/blog/post/gracefully-stopping-docker-containers/)

exec-ing the server allows the process to directly handling any signals